### PR TITLE
Update the erlang versions allowed (based on those used in leofs)

### DIFF
--- a/erlcloud/rebar.config
+++ b/erlcloud/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R15B03|R16B*|17"}.
+{require_otp_vsn, "18|19|20"}.
 
 {deps, [
         {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.6.0"}}},


### PR DESCRIPTION
A dependency (erlcloud) is dropping support for R16. Since R17 isn't used in leo_commons (another dependency), I think it's safe to drop support for <18.